### PR TITLE
implements function destroy saleController

### DIFF
--- a/app/Http/Controllers/API/SaleController.php
+++ b/app/Http/Controllers/API/SaleController.php
@@ -37,4 +37,11 @@ class SaleController extends Controller
         $sales = Sale::where('saler_id', $SalerId)->get();
         return response()->json($sales);
     }
+
+    public function destroy($id)
+    {
+        Sale::find($id)->delete();
+        return response()->json(null, 204);
+
+    }
 }


### PR DESCRIPTION
Now it is possible to delete a sale before deleting a seller, before it was impossible, because when we tried to delete a seller with a linked sale it gave an ERROR.